### PR TITLE
Update RectPackContext to be a ref object

### DIFF
--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,0 +1,1 @@
+test_stb_rect_pack

--- a/tests/test_stb_rect_pack.nim
+++ b/tests/test_stb_rect_pack.nim
@@ -1,11 +1,94 @@
-import unittest
-import stb_rect_pack
+import 
+    unittest, 
+    stb_rect_pack, 
+    sequtils, 
+    sugar,
+    random
 
 suite "newRectPackContext":
     test "creates a RectPackContext":
         check newRectPackContext(100, 100, 100) != nil
     
+suite "finalizeRectPackContext":
+    test "frees the resources of a RectPackContext":
+        finalizeRectPackContext(newRectPackContext(100, 100, 100))
+
+suite "setHeuristic":
+    test "sets the heuristic to use by the RectPackContext":
+        discard newRectPackContext(100, 100, 100).setHeuristic(Heuristic.hSkylineDefault)
+
+    test "sets the heuristic to use by the RectPackContext":
+        let context = newRectPackContext(100, 100, 100).setHeuristic(Heuristic.hSkylineBFSortHeight)
+
+        let rects = @[
+            # Try packing an empty rectangle.
+            Rect(
+                width: 0,
+                height: 0,
+                x: 0,
+                y: 0,
+            ), 
+            Rect(
+                width: 50,
+                height: 50,
+                x: 0,
+                y: 0,
+            ),
+        ]
+
+        check context.packRects(rects)
+
 suite "packRects":
+    test "can be called in succession":
+        let 
+            context = newRectPackContext(10, 30, 10)
+            rects1 = @[Rect(width: 10, height: 10)]
+            rects2 = @[Rect(width: 10, height: 10)]
+            rects3 = @[Rect(width: 10, height: 10)]
+
+        check context.packRects(rects1)
+        check context.packRects(rects2)
+        check context.packRects(rects3);
+
+        check rects1 == @[Rect(
+            width: 10,
+            height: 10,
+            x: 0,
+            y: 0,
+            was_packed: true,
+        )]
+
+        check rects2 == @[Rect(
+            width: 10,
+            height: 10,
+            x: 0,
+            y: 10,
+            was_packed: true,
+        )]
+
+        check rects3 == @[Rect(
+            width: 10,
+            height: 10,
+            x: 0,
+            y: 20,
+            was_packed: true,
+        )]
+
+    test "returns false when the rectangles do not fit":
+        let context = newRectPackContext(100, 100, 100)
+
+        let rects = @[
+            # Try packing too large of a rectangle.
+            Rect(
+                width: 110,
+                height: 110,
+                x: 0,
+                y: 0,
+            ),
+        ]
+
+        check context.packRects(rects) == false # Should fail as the rectangle is too large.
+
     test "packs rectangles":
         let context = newRectPackContext(10, 30, 10)
 
@@ -56,3 +139,26 @@ suite "packRects":
             ),
         ]
     
+    test "stress test - skyline default":
+        let context = newRectPackContext(1000, 1000, 100)
+
+        let rects = toSeq(1..100).map(_ => 
+            Rect(
+                width: rand(1..6).cint,
+                height: rand(1..6).cint
+            )
+        )
+
+        check context.packRects(rects)
+
+    test "stress test - skyline best fit":
+        let context = newRectPackContext(1000, 1000, 100).setHeuristic(Heuristic.hSkylineBFSortHeight)
+
+        let rects = toSeq(1..100).map(_ => 
+            Rect(
+                width: rand(1..6).cint,
+                height: rand(1..6).cint
+            )
+        )
+
+        check context.packRects(rects)


### PR DESCRIPTION
- Add more tests. 
- Rework `RectPackContext` to be a ref object.
- Make `finalizeRectPackContext` public for testing.